### PR TITLE
비교 순위 부분에서 지표 가중치가 종목 리스트에 반영되지 않는 문제 해결

### DIFF
--- a/src/custom-graph/pages/compare.css
+++ b/src/custom-graph/pages/compare.css
@@ -4,7 +4,7 @@
 }
 
 h3 {
-  font-size: 17;
+  font-size: 20px;
   font-weight: bold;
   margin-bottom: 12px;
 }
@@ -29,6 +29,7 @@ h3 {
 .index-name > div > p {
   margin: 0;
   padding-left: 4px;
+  font-size: 14px;
 }
 
 .profit-color {
@@ -146,8 +147,18 @@ h3 {
 
 .index-sample > label > input {
   margin-right: 10px;
+  cursor: pointer;
 }
 
 [type="radio"]:checked {
   accent-color: #da0000;
+}
+
+.index-sample > label {
+  font-size: 15px;
+}
+
+.sample-list {
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/custom-graph/pages/compare.js
+++ b/src/custom-graph/pages/compare.js
@@ -2,15 +2,17 @@
 import React, { useState, useRef, useContext, useEffect } from "react";
 import { Button } from "react-bootstrap";
 import "./compare.css";
-import { WeightContext } from "../../weightedgraph/weightcontext";
+import { WeightContext2 } from "../../weightedgraph/weightcontext2";
+import Scatter from "../../clustering/components/scatter";
 
 function CustomGraphCompare() {
+  const { sliderValues2, setSliderValues2 } = useContext(WeightContext2);
   const [sections, setSections] = useState([
-    { name: "수익성", color: "#FF7676", percentage: 30 },
-    { name: "안정성", color: "#FFDD87", percentage: 10 },
-    { name: "활동성", color: "#91D600", percentage: 30 },
-    { name: "생산성", color: "#87D4FF", percentage: 25 },
-    { name: "오공 지수", color: "#C376FF", percentage: 5 },
+    { name: "수익성", color: "#FF7676", percentage: sliderValues2[0] },
+    { name: "안정성", color: "#FFDD87", percentage: sliderValues2[1] },
+    { name: "활동성", color: "#91D600", percentage: sliderValues2[2] },
+    { name: "생산성", color: "#87D4FF", percentage: sliderValues2[3] },
+    { name: "오공 지수", color: "#C376FF", percentage: sliderValues2[4] },
   ]);
 
   const graphContainerRef = useRef(null);
@@ -66,6 +68,7 @@ function CustomGraphCompare() {
     updatedSections[updatedSections.length - 1].percentage += difference;
 
     setSections(updatedSections);
+    setSliderValues2(updatedSections.map((section) => section.percentage));
     console.log(sections);
   };
 
@@ -85,58 +88,51 @@ function CustomGraphCompare() {
   };
 
   const handleSample = (index) => {
-    switch (index) {
-      case 0:
-        // 수익성 50%, 안정성 5%, 나머지는 15%씩
-        setSections([
-          { name: "수익성", color: "#FF7676", percentage: 50 },
-          { name: "안정성", color: "#FFDD87", percentage: 5 },
-          { name: "활동성", color: "#91D600", percentage: 15 },
-          { name: "생산성", color: "#87D4FF", percentage: 15 },
-          { name: "오공 지수", color: "#C376FF", percentage: 15 },
-        ]);
-        break;
-      case 1:
-        // 안정성 50%, 수익성 5%, 나머지는 15%씩
-        setSections([
-          { name: "수익성", color: "#FF7676", percentage: 5 },
-          { name: "안정성", color: "#FFDD87", percentage: 50 },
-          { name: "활동성", color: "#91D600", percentage: 15 },
-          { name: "생산성", color: "#87D4FF", percentage: 15 },
-          { name: "오공 지수", color: "#C376FF", percentage: 15 },
-        ]);
-        break;
-      case 2:
-        // 활동성 50%, 안정성 5%, 나머지는 15%씩
-        setSections([
-          { name: "수익성", color: "#FF7676", percentage: 15 },
-          { name: "안정성", color: "#FFDD87", percentage: 5 },
-          { name: "활동성", color: "#91D600", percentage: 50 },
-          { name: "생산성", color: "#87D4FF", percentage: 15 },
-          { name: "오공 지수", color: "#C376FF", percentage: 15 },
-        ]);
-        break;
-      case 3:
-        // 생산성 50%, 안정성 5%, 나머지는 15%씩
-        setSections([
-          { name: "수익성", color: "#FF7676", percentage: 15 },
-          { name: "안정성", color: "#FFDD87", percentage: 5 },
-          { name: "활동성", color: "#91D600", percentage: 15 },
-          { name: "생산성", color: "#87D4FF", percentage: 50 },
-          { name: "오공 지수", color: "#C376FF", percentage: 15 },
-        ]);
-        break;
-      case 4:
-        // 오공 지수 60%, 나머지는 10%씩
-        setSections([
-          { name: "수익성", color: "#FF7676", percentage: 10 },
-          { name: "안정성", color: "#FFDD87", percentage: 10 },
-          { name: "활동성", color: "#91D600", percentage: 10 },
-          { name: "생산성", color: "#87D4FF", percentage: 10 },
-          { name: "오공 지수", color: "#C376FF", percentage: 60 },
-        ]);
-        break;
-    }
+    const samples = [
+      [
+        { name: "수익성", color: "#FF7676", percentage: 50 },
+        { name: "안정성", color: "#FFDD87", percentage: 5 },
+        { name: "활동성", color: "#91D600", percentage: 15 },
+        { name: "생산성", color: "#87D4FF", percentage: 15 },
+        { name: "오공 지수", color: "#C376FF", percentage: 15 },
+      ],
+      [
+        { name: "수익성", color: "#FF7676", percentage: 5 },
+        { name: "안정성", color: "#FFDD87", percentage: 50 },
+        { name: "활동성", color: "#91D600", percentage: 15 },
+        { name: "생산성", color: "#87D4FF", percentage: 15 },
+        { name: "오공 지수", color: "#C376FF", percentage: 15 },
+      ],
+      [
+        { name: "수익성", color: "#FF7676", percentage: 15 },
+        { name: "안정성", color: "#FFDD87", percentage: 5 },
+        { name: "활동성", color: "#91D600", percentage: 50 },
+        { name: "생산성", color: "#87D4FF", percentage: 15 },
+        { name: "오공 지수", color: "#C376FF", percentage: 15 },
+      ],
+      [
+        { name: "수익성", color: "#FF7676", percentage: 15 },
+        { name: "안정성", color: "#FFDD87", percentage: 5 },
+        { name: "활동성", color: "#91D600", percentage: 15 },
+        { name: "생산성", color: "#87D4FF", percentage: 50 },
+        { name: "오공 지수", color: "#C376FF", percentage: 15 },
+      ],
+      [
+        { name: "수익성", color: "#FF7676", percentage: 10 },
+        { name: "안정성", color: "#FFDD87", percentage: 10 },
+        { name: "활동성", color: "#91D600", percentage: 10 },
+        { name: "생산성", color: "#87D4FF", percentage: 10 },
+        { name: "오공 지수", color: "#C376FF", percentage: 60 },
+      ],
+    ];
+    setSections(samples[index]);
+    setSliderValues2(samples[index].map((section) => section.percentage));
+
+    // 추가된 부분: sliderValues 상태 확인
+    console.log(
+      "Sampled Slider Values: ",
+      samples[index].map((section) => section.percentage)
+    );
   };
 
   return (
@@ -183,61 +179,68 @@ function CustomGraphCompare() {
           </div>
         ))}
       </div>
-      <div className="sample-info">
-        <img src="info-icon.svg" alt="info" width="20" />
-        <p>비율을 어떻게 설정해야할지 모르겠다면 아래 샘플을 이용해보세요!</p>
-      </div>
-      <div className="index-sample">
-        <label>
-          <input
-            type="radio"
-            id="sample2"
-            name="sample2"
-            value="sample2"
-            onClick={() => handleSample(0)}
-          />
-          <span>수익성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
-        </label>
-        <label>
-          <input
-            type="radio"
-            id="sample1"
-            name="sample2"
-            value="sample1"
-            onClick={() => handleSample(1)}
-          />
-          <span>안정성</span>이 높으면 <span>수익성</span>이 낮아도 좋아요!
-        </label>
-        <label>
-          <input
-            type="radio"
-            id="sample3"
-            name="sample2"
-            value="sample3"
-            onClick={() => handleSample(2)}
-          />
-          <span>활동성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
-        </label>
-        <label>
-          <input
-            type="radio"
-            id="sample4"
-            name="sample2"
-            value="sample4"
-            onClick={() => handleSample(3)}
-          />
-          <span>생산성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
-        </label>
-        <label>
-          <input
-            type="radio"
-            id="sample5"
-            name="sample2"
-            value="sample5"
-            onClick={() => handleSample(4)}
-          />
-          사람들의 <span>심리</span>가 제일 궁금해요!
-        </label>
+      <div className="sample-list">
+        <div>
+          <div className="sample-info">
+            <img src="info-icon.svg" alt="info" width="20" />
+            <p>
+              비율을 어떻게 설정해야할지 모르겠다면 아래 샘플을 이용해보세요!
+            </p>
+          </div>
+          <div className="index-sample">
+            <label>
+              <input
+                type="radio"
+                id="sample2"
+                name="sample2"
+                value="sample2"
+                onClick={() => handleSample(0)}
+              />
+              <span>수익성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
+            </label>
+            <label>
+              <input
+                type="radio"
+                id="sample1"
+                name="sample2"
+                value="sample1"
+                onClick={() => handleSample(1)}
+              />
+              <span>안정성</span>이 높으면 <span>수익성</span>이 낮아도 좋아요!
+            </label>
+            <label>
+              <input
+                type="radio"
+                id="sample3"
+                name="sample2"
+                value="sample3"
+                onClick={() => handleSample(2)}
+              />
+              <span>활동성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
+            </label>
+            <label>
+              <input
+                type="radio"
+                id="sample4"
+                name="sample2"
+                value="sample4"
+                onClick={() => handleSample(3)}
+              />
+              <span>생산성</span>이 높으면 <span>안정성</span>이 낮아도 좋아요!
+            </label>
+            <label>
+              <input
+                type="radio"
+                id="sample5"
+                name="sample2"
+                value="sample5"
+                onClick={() => handleSample(4)}
+              />
+              사람들의 <span>심리</span>가 제일 궁금해요!
+            </label>
+          </div>
+        </div>
+        <Scatter />
       </div>
     </div>
   );

--- a/src/custom-graph/pages/main.js
+++ b/src/custom-graph/pages/main.js
@@ -5,7 +5,7 @@ import Scatter from "../../clustering/components/scatter";
 import "./compare.css";
 import { WeightContext } from "../../weightedgraph/weightcontext";
 
-function CustomGraphCompare() {
+function CustomGraph() {
   const { sliderValues, setSliderValues } = useContext(WeightContext);
   const [sections, setSections] = useState([
     { name: "수익성", color: "#FF7676", percentage: sliderValues[0] },
@@ -132,7 +132,7 @@ function CustomGraphCompare() {
 
   return (
     <div className="main-body">
-      <h3>비교 순위</h3>
+      <h3>순위</h3>
       <div className="index-info">
         <div className="index-name">
           <div className="profit">
@@ -241,4 +241,4 @@ function CustomGraphCompare() {
   );
 }
 
-export default CustomGraphCompare;
+export default CustomGraph;

--- a/src/main/pages/main.js
+++ b/src/main/pages/main.js
@@ -1,11 +1,13 @@
 import React from "react";
 import NavbarHeader from "../../navbar/components/navbar";
 import CustomGraph from "../../custom-graph/pages/main";
+import CustomGraphCompare from "../../custom-graph/pages/compare";
 import "./styles/style.css";
 import Lineup from "../../weightedgraph/lineup";
 import Lineup2 from "../../weightedgraph/lineup2";
 import { Row, Col, Container } from "react-bootstrap";
 import { WeightProvider } from "../../weightedgraph/weightcontext";
+import { WeightProviderCompare } from "../../weightedgraph/weightcontext2";
 
 export default function main() {
   return (
@@ -20,10 +22,10 @@ export default function main() {
             </WeightProvider>
           </Col>
           <Col xs={6}>
-            <WeightProvider>
-              <CustomGraph />
-              <Lineup2></Lineup2>
-            </WeightProvider>
+            <WeightProviderCompare>
+              <CustomGraphCompare />
+              <Lineup2 />
+            </WeightProviderCompare>
           </Col>
         </Row>
       </Container>

--- a/src/weightedgraph/lineup2.js
+++ b/src/weightedgraph/lineup2.js
@@ -2,10 +2,10 @@ import React, { useEffect, useRef, useState, useContext } from "react";
 import * as d3 from "d3";
 import _ from "lodash";
 import weightData from "./weightcode.json";
-import { WeightContext } from "./weightcontext";
+import { WeightContext2 } from "./weightcontext2";
 
 const Lineup2 = () => {
-  const { sliderValues } = useContext(WeightContext);
+  const { sliderValues2 } = useContext(WeightContext2);
   const svgRef = useRef();
   const titleRef = useRef();
   const [data, setData] = useState([]);
@@ -26,9 +26,9 @@ const Lineup2 = () => {
   }, []);
 
   useEffect(() => {
-    console.log("L_listen", sliderValues);
-    L_listen(sliderValues, weightData);
-  }, [sliderValues]);
+    console.log("L_listen", sliderValues2);
+    L_listen(sliderValues2, weightData);
+  }, [sliderValues2]);
 
   const rankSort = async (w_d, w_s, w_n, w_m, w_q, data) => {
     console.log("가중치", w_d, w_s, w_n, w_m, w_q, data);
@@ -51,10 +51,10 @@ const Lineup2 = () => {
     return rank;
   };
 
-  const L_listen = async (sliderValues, d) => {
-    const [c0, c1, c2, c3, c4] = sliderValues;
+  const L_listen = async (sliderValues2, d) => {
+    const [c0, c1, c2, c3, c4] = sliderValues2;
     const svg = d3.select(svgRef.current);
-    console.log("Current Slider Values: ", sliderValues);
+    console.log("Current Slider Values: ", sliderValues2);
     console.log("data: ", d);
     rankSort(c0, c1, c2, c3, c4, d)
       .then((sortedData) => {

--- a/src/weightedgraph/weightcontext2.js
+++ b/src/weightedgraph/weightcontext2.js
@@ -1,0 +1,15 @@
+// WeightContext.js
+import React, { createContext, useState } from "react";
+
+export const WeightContext2 = createContext();
+
+export const WeightProviderCompare = ({ children }) => {
+  console.log({ children });
+  const [sliderValues2, setSliderValues2] = useState([20, 20, 20, 20, 20]);
+
+  return (
+    <WeightContext2.Provider value={{ sliderValues2, setSliderValues2 }}>
+      {children}
+    </WeightContext2.Provider>
+  );
+};


### PR DESCRIPTION
### PR 타입
-[] 기능 추가
-[] 기능 수정
-[] 기능 삭제
-[✔] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/30-compare-ranking -> main

### 변경 사항
- 순위와 비교 순위의 Weight Context를 분리하여 별도로 context를 관리할 수 있게 했습니다.
- 브랜치 이름 변경으로 새로 PR을 작성했습니다.
(#29 Closed)

### 테스트 결과
1. 순위 부분에서 그래프 가중치 조절 및 샘플 클릭 시, 가중치 비율에 따라 순위가 변경되는 것을 확인합니다.
2. 비교 순위 부분에서 그래프 가중치 조절 및 샘플 클릭 시, 가중치 비율에 따라 순위가 별도로 변경되는 것을 확인합니다.

https://github.com/oogong/frontend/assets/140503027/2a6082ba-f6cf-4a17-a82f-30ca12dad9c4

