### PR TITLE
종목 별 시세 데이터 표기

### DIFF
--- a/public/down-icon.svg
+++ b/public/down-icon.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="6" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 6L0 0H8L4 6Z" fill="#0029FF"/>
+</svg>

--- a/public/up-icon.svg
+++ b/public/up-icon.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="6" viewBox="0 0 8 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 0L8 6H0L4 0Z" fill="#FF0000"/>
+</svg>

--- a/src/company/components/companyStock/index.css
+++ b/src/company/components/companyStock/index.css
@@ -1,0 +1,39 @@
+.company-stock {
+    display: flex;
+    flex-direction: column;
+    padding: 0px 15px 5px 0px;
+    margin: 0px 15px 15px 5px;
+    border-right: 2px solid rgba(0, 0, 0, 0.15);
+  }
+  
+  .company-stock .name {
+    font-size: 22px;
+  }
+  
+  .company-stock .code {
+    font-size: 15px;
+  }
+  
+  .company-stock .price {
+    font-size: 18px;
+  }
+  
+  .up-and-down {
+    display: flex;
+    align-items: center;
+    padding: 3px 0px 0px 3px;
+    width: 8px;
+  }
+  
+  .up-and-down p {
+    font-size: 14px;
+    margin-bottom: 0px;
+  }
+  
+  
+  
+  
+  
+  
+  
+  

--- a/src/company/components/companyStock/index.jsx
+++ b/src/company/components/companyStock/index.jsx
@@ -5,6 +5,7 @@ import {
   disconnectSocket,
   requestCurrentPrice,
 } from "../../service/stockPrice";
+import "./index.css";
 
 export default function CompanyStock(props) {
   const [stockCompare, setStockCompare] = useState(0);
@@ -38,6 +39,17 @@ export default function CompanyStock(props) {
       disconnectSocket();
     };
   }, [props.code]);
+
+  useEffect(() => {
+    if (stockCompare < 0) {
+      setCompare(stockCompare * `-1`);
+      setColor("#0029FF");
+    } else {
+      setCompare(stockCompare);
+      setColor("#FF0000");
+    }
+  }, [stockCompare]);
+
   return (
     <div className="company-stock">
       <p className="name">{props.name}</p>

--- a/src/company/components/companyStock/index.jsx
+++ b/src/company/components/companyStock/index.jsx
@@ -1,12 +1,60 @@
-import React from 'react'
-import './../styles/companyStock.css'
+import React, { useEffect, useState } from "react";
+import "./../styles/companyStock.css";
+import { connectSocket, joinRoom } from "../../service/stockPrice";
+import {
+  disconnectSocket,
+  requestCurrentPrice,
+} from "../../service/stockPrice";
 
 export default function CompanyStock(props) {
+  const [stockCompare, setStockCompare] = useState(0);
+  const [compare, setCompare] = useState(0);
+  const [stockPrice, setStockPrice] = useState(props.price);
+  const [color, setColor] = useState("red");
+
+  const handlePrice = (loadedPrice) => {
+    setStockPrice(loadedPrice);
+  };
+
+  const handleCompare = (loadedCompare) => {
+    setStockCompare(loadedCompare);
+  };
+
+  useEffect(() => {
+    console.log("code: ", props.code);
+    connectSocket();
+
+    joinRoom(props.code, handlePrice, handleCompare)
+      .then((price) => {
+        console.log("Price loaded:", price);
+      })
+      .catch((error) => {
+        console.error("Error joining price room:", error);
+      });
+
+    requestCurrentPrice(props.code, handlePrice, handleCompare);
+
+    return () => {
+      disconnectSocket();
+    };
+  }, [props.code]);
   return (
-    <div style={{display:"flex", flexDirection:"column", paddingRight:"10px", marginRight:'10px', borderRight:"2px solid #c1c1c1"}}>
-      <p className='name'>{props.name}</p>
-      <p className='code'>{props.code}</p>
-      <p className='price'>{props.price}</p>
+    <div className="company-stock">
+      <p className="name">{props.name}</p>
+      <p className="code">{props.code}</p>
+      <p className="price" style={{ color: color }}>
+        {stockPrice}
+      </p>
+      <div className="up-and-down">
+        <img
+          src={color === "#FF0000" ? "up-icon.svg" : "down-icon.svg"}
+          alt="up-and-down"
+          style={{ width: "15px", height: "15px" }}
+        />
+        <p className="compare" style={{ color: color }}>
+          {compare}
+        </p>
+      </div>
     </div>
-  )
+  );
 }

--- a/src/company/service/stockPrice.js
+++ b/src/company/service/stockPrice.js
@@ -64,3 +64,11 @@ export const requestCurrentPrice = (stockCode, handlePrice, handleCompare) => {
     });
   });
 };
+
+export const disconnectSocket = () => {
+  if (socket) {
+    console.log("Price Disconnecting socket");
+    socket.disconnect();
+    socket = null;
+  }
+};

--- a/src/company/service/stockPrice.js
+++ b/src/company/service/stockPrice.js
@@ -40,3 +40,27 @@ export const joinRoom = (roomCode, handlePrice, handleCompare) => {
     });
   });
 };
+
+export const requestCurrentPrice = (stockCode, handlePrice, handleCompare) => {
+  return new Promise((resolve, reject) => {
+    console.log(`Requesting current price for stockCode: ${stockCode}`);
+    socket.emit("request current price", { stockCode });
+
+    socket.on("current price", (response) => {
+      if (response.status === "success") {
+        handlePrice(response.price);
+        handleCompare(response.compare);
+        resolve(response.price);
+      } else {
+        console.log("Price not sent");
+        reject(new Error("price not sent"));
+      }
+    });
+
+    socket.on("error", (error) => {
+      console.error("Error requesting current price:", error);
+      handlePrice(0);
+      handleCompare(0);
+    });
+  });
+};

--- a/src/company/service/stockPrice.js
+++ b/src/company/service/stockPrice.js
@@ -17,3 +17,26 @@ export const connectSocket = () => {
   return socket;
 };
 
+export const joinRoom = (roomCode, handlePrice, handleCompare) => {
+  return new Promise((resolve, reject) => {
+    console.log(`Joining price room with roomCode: ${roomCode}`);
+    socket.emit("join price room", { roomCode });
+
+    socket.on("load price", (price) => {
+      if (!price) {
+        handlePrice(0);
+        handleCompare(0);
+      } else {
+        handlePrice(price.price);
+        handleCompare(price.compare);
+        console.log("load price", price.price);
+      }
+      resolve(price);
+    });
+
+    socket.on("error", (error) => {
+      console.error("Error joining price room:", error);
+      reject(error);
+    });
+  });
+};

--- a/src/company/service/stockPrice.js
+++ b/src/company/service/stockPrice.js
@@ -1,0 +1,19 @@
+import { io } from "socket.io-client";
+
+const CHAT_APP_SOCKET_URL =
+  process.env.REACT_APP_LOCAL_API_URL || "http://localhost:5000";
+
+let socket = null;
+
+export const connectSocket = () => {
+  if (!socket) {
+    console.log(`Connecting to ${CHAT_APP_SOCKET_URL}/price`);
+    socket = io(CHAT_APP_SOCKET_URL, {
+      path: "/price",
+    });
+  } else {
+    console.log("Socket already connected");
+  }
+  return socket;
+};
+


### PR DESCRIPTION
### PR 타입
-[✔️] 기능 추가
-[] 기능 수정
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/62-realtime-price -> main

### 변경 사항
- 종목 상세페이지 좌측 상단에 실시간 시세 정보를 반영하는 가격을 표기하도록 변경했습니다.
- 가격과 함께 전일대비 가격 변동도 함께 표시됩니다.

### 테스트 결과
- 메인페이지에서 우측 상단의 검색창에 `삼성전자`를 검색하여 상세 페이지로 접속합니다.
<img width="1710" alt="image" src="https://github.com/oogong/frontend/assets/140503027/5761acb0-8f3d-4eca-9df8-781563fbbf9f">

- 상세페이지 좌측 상단에 종목명, 종목 코드와 함께 시세 데이터가 조회되는 것을 확인합니다.
<img width="1709" alt="image" src="https://github.com/oogong/frontend/assets/140503027/3f7546f6-49af-487b-9d71-8d512cb6e6ca">

- `평일 오전 9시부터 오후 3시 20분까지(주식 장이 열린 시간)`는 실시간으로 시세 데이터가 업데이트됩니다.
- `평일 오후 3시 32분`에는 그날 종가 데이터를 최종적으로 업데이트하며 해당 데이터가 다음 장이 열리는 시간까지 조회됩니다.